### PR TITLE
Report haml-lint errors as violations

### DIFF
--- a/lib/haml_lint/violation.rb
+++ b/lib/haml_lint/violation.rb
@@ -1,10 +1,12 @@
 module HamlLint
   class Violation
+    VIOLATION_LEVEL_ERROR = "E".freeze
+
     VIOLATION_REGEX = /\A
       (?<path>.+):
       (?<line_number>\d+)\s+
       \[(?<violation_level>\w)\]\s+
-      (?<rule_name>[\w\s]+):\s+
+      ((?<rule_name>[\w\s]+):\s+)?
       (?<message>.+)
       \n?
     \z/x
@@ -25,7 +27,11 @@ module HamlLint
     end
 
     def line_number
-      parts[:line_number].to_i
+      if account_for_zero_indexing?
+        parts[:line_number].to_i + 1
+      else
+        parts[:line_number].to_i
+      end
     end
 
     def message
@@ -44,7 +50,12 @@ module HamlLint
       {
         line_number: matches[:line_number],
         message: matches[:message],
+        violation_level: matches[:violation_level],
       }
+    end
+
+    def account_for_zero_indexing?
+      parts[:violation_level] == VIOLATION_LEVEL_ERROR
     end
 
     attr_reader :violation

--- a/spec/lib/haml_lint/runner_spec.rb
+++ b/spec/lib/haml_lint/runner_spec.rb
@@ -38,6 +38,24 @@ describe HamlLint::Runner do
         expect(violations.size).to eq(0)
       end
     end
+
+    context "when the HAML is invalid" do
+      it "returns error as violation" do
+        invalid_content = <<~HAML
+          .main
+            %div
+                %span
+        HAML
+        config = ConfigOptions.new("", "haml.yml")
+        file = SourceFile.new("bar.html.haml", invalid_content)
+        runner = HamlLint::Runner.new(config)
+
+        violations = runner.violations_for(file)
+
+        expect(violations.size).to eq(1)
+        expect(violations.first[:line]).to eq 3
+      end
+    end
   end
 
   def file_content

--- a/spec/lib/haml_lint/violation_spec.rb
+++ b/spec/lib/haml_lint/violation_spec.rb
@@ -11,6 +11,14 @@ describe HamlLint::Violation do
       end
     end
 
+    context "given a valid error" do
+      it "parses the error" do
+        parsable = HamlLint::Violation.parsable?(error_message)
+
+        expect(parsable).to eq(true)
+      end
+    end
+
     context "given an invalid violation" do
       it "should not be able to parse" do
         parsable = HamlLint::Violation.parsable?("Invalid string")
@@ -21,39 +29,64 @@ describe HamlLint::Violation do
   end
 
   describe "#line_number" do
-    it "returns line number" do
-      violation = HamlLint::Violation.new(violation_string(line_number: 1))
+    context "when the message is a violation" do
+      it "returns line number" do
+        violation = HamlLint::Violation.new(violation_string(line_number: 1))
 
-      expect(violation.line_number).to eq(1)
+        expect(violation.line_number).to eq(1)
+      end
     end
 
-    it "raises with an invalid string" do
-      violation = HamlLint::Violation.new("invalid string")
+    context "when the message is an error" do
+      it "returns the reported line number plus one" do
+        violation = HamlLint::Violation.new(error_message(line_number: 4))
 
-      expect { violation.line_number }.
-        to raise_error(
-          HamlLint::ViolationParseError,
-          /Violation: "invalid string"/,
-        )
+        expect(violation.line_number).to eq(5)
+      end
+    end
+
+    context "when the message is invalid" do
+      it "raises with an invalid string" do
+        violation = HamlLint::Violation.new("invalid string")
+
+        expect { violation.line_number }.
+          to raise_error(
+            HamlLint::ViolationParseError,
+            /Violation: "invalid string"/,
+          )
+      end
     end
   end
 
   describe "#message" do
-    it "returns the message" do
-      message = "Trailing Whitespace Violation: It should not have whitespace."
-      violation = HamlLint::Violation.new(violation_string(message: message))
+    context "when the message is a violation" do
+      it "returns the message" do
+        message = "Trailing Whitespace Violation: It should not have whitespace"
+        violation = HamlLint::Violation.new(violation_string(message: message))
 
-      expect(violation.message).to eq(message)
+        expect(violation.message).to eq(message)
+      end
     end
 
-    it "raises with an invalid string" do
-      violation = HamlLint::Violation.new("invalid string")
+    context "when the message is an error" do
+      it "returns the message" do
+        message = "You did it wrong"
+        violation = HamlLint::Violation.new(error_message(message: message))
 
-      expect { violation.message }.
-        to raise_error(
-          HamlLint::ViolationParseError,
-          /Violation: "invalid string"/,
-        )
+        expect(violation.message).to eq(message)
+      end
+    end
+
+    context "when the message is invalid" do
+      it "raises with an invalid string" do
+        violation = HamlLint::Violation.new("invalid string")
+
+        expect { violation.message }.
+          to raise_error(
+            HamlLint::ViolationParseError,
+            /Violation: "invalid string"/,
+          )
+      end
     end
   end
 
@@ -63,5 +96,9 @@ describe HamlLint::Violation do
 
   def default_violation_message
     "8 spaces used for indentation, but the rest of the document legit."
+  end
+
+  def error_message(line_number: 1, message: "Something went wrong.")
+    "bar.html.haml:#{line_number} [E] #{message}"
   end
 end


### PR DESCRIPTION
When haml-lint reports an error, e.g. invalid syntax, it does not
include a rule name in the message. The regex for parsing these messages
is assuming a rule name will be present and is failing to capture error
messages because of it.

Additionally, when reporting errors, haml-lint seems to use zero-based
indexing.

This commit:

* Updates `HamlLint::Violation` regex pattern to have an optional rule
  name, so errors are matched
* Updates `HamlLint::Violation#line_number` to increment the line number
  by one when the message is an error, so the correct line number is
  reported

Related: https://github.com/houndci/hound/pull/1112