### PR TITLE
Report scss-lint errors as violations

### DIFF
--- a/lib/scss_lint/violation.rb
+++ b/lib/scss_lint/violation.rb
@@ -4,7 +4,7 @@ module ScssLint
       (?<path>.+):
       (?<line_number>\d+)\s+
       \[(?<violation_level>\w)\]\s+
-      (?<rule_name>\w+):\s+
+      (?<rule_name>[\w\s]+):\s+
       (?<message>.+)
       \n?
     \z/x

--- a/spec/lib/scss_lint/runner_spec.rb
+++ b/spec/lib/scss_lint/runner_spec.rb
@@ -38,6 +38,24 @@ describe ScssLint::Runner do
         expect(violations.size).to eq(0)
       end
     end
+
+    context "when the SCSS is invalid" do
+      it "returns error as violation" do
+        invalid_content = <<~SCSS
+          .main {
+            display: "none";
+          {
+        SCSS
+        config = ConfigOptions.new("", "scss.yml")
+        file = SourceFile.new("bar.scss", invalid_content)
+        runner = ScssLint::Runner.new(config)
+
+        violations = runner.violations_for(file)
+
+        expect(violations.size).to eq(1)
+        expect(violations.first[:line]).to eq 3
+      end
+    end
   end
 
   def file_content

--- a/spec/lib/scss_lint/violation_spec.rb
+++ b/spec/lib/scss_lint/violation_spec.rb
@@ -11,6 +11,14 @@ describe ScssLint::Violation do
       end
     end
 
+    context "fiven a valid error" do
+      it "parses the error" do
+        parsable = ScssLint::Violation.parsable?(error_message)
+
+        expect(parsable).to eq(true)
+      end
+    end
+
     context "given an invalid violation" do
       it "should not be able to parse" do
         parsable = ScssLint::Violation.parsable?("Invalid string")
@@ -21,39 +29,64 @@ describe ScssLint::Violation do
   end
 
   describe "#line_number" do
-    it "returns line number" do
-      violation = ScssLint::Violation.new(violation_string(line_number: 1))
+    context "when the message is a violation" do
+      it "returns line number" do
+        violation = ScssLint::Violation.new(violation_string(line_number: 1))
 
-      expect(violation.line_number).to eq(1)
+        expect(violation.line_number).to eq(1)
+      end
     end
 
-    it "raises with an invalid string" do
-      violation = ScssLint::Violation.new("invalid string")
+    context "when the message is an error" do
+      it "returns the reported line number" do
+        violation = ScssLint::Violation.new(error_message(line_number: 4))
 
-      expect { violation.line_number }.
-        to raise_error(
-          ScssLint::ViolationParseError,
-          /Violation: "invalid string"/,
-        )
+        expect(violation.line_number).to eq(4)
+      end
+    end
+
+    context "when the message is invalid" do
+      it "raises with an invalid string" do
+        violation = ScssLint::Violation.new("invalid string")
+
+        expect { violation.line_number }.
+          to raise_error(
+            ScssLint::ViolationParseError,
+            /Violation: "invalid string"/,
+          )
+      end
     end
   end
 
   describe "#message" do
-    it "returns the message" do
-      message = "Trailing Whitespace Violation: It should not have whitespace."
-      violation = ScssLint::Violation.new(violation_string(message: message))
+    context "when the message is a violation" do
+      it "returns the message" do
+        message = "Trailing Whitespace Violation: It should not have whitespace"
+        violation = ScssLint::Violation.new(violation_string(message: message))
 
-      expect(violation.message).to eq(message)
+        expect(violation.message).to eq(message)
+      end
     end
 
-    it "raises with an invalid string" do
-      violation = ScssLint::Violation.new("invalid string")
+    context "when the message is an error" do
+      it "returns the message" do
+        message = "You did it wrong"
+        violation = ScssLint::Violation.new(error_message(message: message))
 
-      expect { violation.message }.
-        to raise_error(
-          ScssLint::ViolationParseError,
-          /Violation: "invalid string"/,
-        )
+        expect(violation.message).to eq(message)
+      end
+    end
+
+    context "when the message is invalid" do
+      it "raises with an invalid string" do
+        violation = ScssLint::Violation.new("invalid string")
+
+        expect { violation.message }.
+          to raise_error(
+            ScssLint::ViolationParseError,
+            /Violation: "invalid string"/,
+          )
+      end
     end
   end
 
@@ -63,5 +96,9 @@ describe ScssLint::Violation do
 
   def default_violation_message
     "Color `#aaaaaa` should be written as `#aaa`"
+  end
+
+  def error_message(line_number: 1, message: "Something went wrong")
+    "file.scss:#{line_number} [E] Syntax Error: #{message}"
   end
 end


### PR DESCRIPTION
scss-lint's rule names can sometimes include a space, e.g. "Syntax
Error". The regex for parsing scss-lint output is assuming rule names to
contain no whitespace and is failing to capture some errors because of
it.

This updates the `ScssLint::Violation` regex pattern to allow spaces in
rule names.

https://trello.com/c/95xQa6Xr