### PR TITLE
Extract common code from review jobs

### DIFF
--- a/lib/haml_lint/violation.rb
+++ b/lib/haml_lint/violation.rb
@@ -1,4 +1,4 @@
-module HamlLint
+module Haml
   class Violation
     VIOLATION_LEVEL_ERROR = "E".freeze
 

--- a/lib/jobs/haml_review_job.rb
+++ b/lib/jobs/haml_review_job.rb
@@ -1,57 +1,16 @@
 require "resque"
 
-require "config_options"
-require "jobs/completed_file_review_job"
-require "haml_lint"
-require "source_file"
-require "haml_lint/runner"
+require "linters/haml_lint"
+require "runner"
 
 class HamlReviewJob
   @queue = :haml_review
 
-  # This job receives the following arguments
-  # - filename
-  # - content
-  # - config
-  # - pull_request_number (pass-through)
-  # - commit_sha (pass-through)
-  # - patch (pass-through)
   def self.perform(attributes)
-    config = config_for(attributes: attributes)
-    file = file_for(attributes: attributes)
-    violations = violations_for(file: file, config: config)
-
-    completed_file_review(
-      file: file,
+    Runner.new(
       attributes: attributes,
-      violations: violations,
-    )
-  end
-
-  def self.completed_file_review(file:, attributes:, violations:)
-    Resque.enqueue(
-      CompletedFileReviewJob,
-      filename: file.path,
-      commit_sha: attributes.fetch("commit_sha"),
-      pull_request_number: attributes.fetch("pull_request_number"),
-      patch: attributes.fetch("patch"),
-      violations: violations,
-    )
-  end
-
-  def self.violations_for(file:, config:)
-    haml_lint_runner = HamlLint::Runner.new(config)
-    haml_lint_runner.violations_for(file)
-  end
-
-  def self.file_for(attributes:)
-    SourceFile.new(
-      attributes.fetch("filename"),
-      attributes.fetch("content"),
-    )
-  end
-
-  def self.config_for(attributes:)
-    ConfigOptions.new(attributes["config"], "haml.yml")
+      linter_class: Linters::HamlLint,
+      config_filename: "haml.yml",
+    ).call
   end
 end

--- a/lib/jobs/scss_review_job.rb
+++ b/lib/jobs/scss_review_job.rb
@@ -1,57 +1,16 @@
 require "resque"
 
-require "config_options"
-require "jobs/completed_file_review_job"
-require "scss_lint"
-require "source_file"
-require "scss_lint/runner"
+require "linters/scss_lint"
+require "runner"
 
 class ScssReviewJob
   @queue = :scss_review
 
-  # This job receives the following arguments
-  # - filename
-  # - content
-  # - config
-  # - pull_request_number (pass-through)
-  # - commit_sha (pass-through)
-  # - patch (pass-through)
   def self.perform(attributes)
-    config = config_for(attributes: attributes)
-    file = file_for(attributes: attributes)
-    violations = violations_for(file: file, config: config)
-
-    completed_file_review(
-      file: file,
+    Runner.new(
       attributes: attributes,
-      violations: violations,
-    )
-  end
-
-  def self.completed_file_review(file:, attributes:, violations:)
-    Resque.enqueue(
-      CompletedFileReviewJob,
-      filename: file.path,
-      commit_sha: attributes.fetch("commit_sha"),
-      pull_request_number: attributes.fetch("pull_request_number"),
-      patch: attributes.fetch("patch"),
-      violations: violations,
-    )
-  end
-
-  def self.violations_for(file:, config:)
-    scss_lint_runner = ScssLint::Runner.new(config)
-    scss_lint_runner.violations_for(file)
-  end
-
-  def self.file_for(attributes:)
-    SourceFile.new(
-      attributes.fetch("filename"),
-      attributes.fetch("content"),
-    )
-  end
-
-  def self.config_for(attributes:)
-    ConfigOptions.new(attributes["config"], "scss.yml")
+      linter_class: Linters::ScssLint,
+      config_filename: "scss.yml",
+    ).call
   end
 end

--- a/lib/linters/haml_lint.rb
+++ b/lib/linters/haml_lint.rb
@@ -1,8 +1,8 @@
 require "haml_lint/violation"
 require "system_call"
 
-module HamlLint
-  class Runner
+module Linters
+  class HamlLint
     def initialize(config, system_call: SystemCall.new)
       @config_file = SourceFile.new(".haml-lint.yml", config.to_yaml)
       @system_call = system_call
@@ -10,7 +10,7 @@ module HamlLint
 
     def violations_for(file)
       violation_strings(file).map do |violation_string|
-        Violation.new(violation_string).to_hash
+        Haml::Violation.new(violation_string).to_hash
       end
     end
 
@@ -38,7 +38,7 @@ module HamlLint
     end
 
     def message_parsable?(string)
-      HamlLint::Violation.parsable?(string)
+      Haml::Violation.parsable?(string)
     end
   end
 end

--- a/lib/linters/scss_lint.rb
+++ b/lib/linters/scss_lint.rb
@@ -1,8 +1,8 @@
 require "scss_lint/violation"
 require "system_call"
 
-module ScssLint
-  class Runner
+module Linters
+  class ScssLint
     def initialize(config, system_call: SystemCall.new)
       @config_file = SourceFile.new(".scss-lint.yml", config.to_yaml)
       @system_call = system_call
@@ -10,7 +10,7 @@ module ScssLint
 
     def violations_for(file)
       violation_strings(file).map do |violation_string|
-        Violation.new(violation_string).to_hash
+        Scss::Violation.new(violation_string).to_hash
       end
     end
 
@@ -38,7 +38,7 @@ module ScssLint
     end
 
     def message_parsable?(string)
-      ScssLint::Violation.parsable?(string)
+      Scss::Violation.parsable?(string)
     end
   end
 end

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -1,0 +1,53 @@
+require "config_options"
+require "source_file"
+require "jobs/completed_file_review_job"
+
+class Runner
+  # This job receives the following arguments
+  # - filename
+  # - content
+  # - config
+  # - pull_request_number (pass-through)
+  # - commit_sha (pass-through)
+  # - patch (pass-through)
+  def initialize(attributes:, linter_class:, config_filename:)
+    @attributes = attributes
+    @linter_class = linter_class
+    @config_filename = config_filename
+  end
+
+  def call
+    violations = linter.violations_for(file)
+    complete_file_review(violations)
+  end
+
+  private
+
+  attr_reader :attributes, :linter_class, :config_filename
+
+  def linter
+    linter_class.new(config)
+  end
+
+  def config
+    ConfigOptions.new(attributes["config"], config_filename)
+  end
+
+  def file
+    SourceFile.new(
+      attributes.fetch("filename"),
+      attributes.fetch("content"),
+    )
+  end
+
+  def complete_file_review(violations)
+    Resque.enqueue(
+      CompletedFileReviewJob,
+      commit_sha: attributes.fetch("commit_sha"),
+      filename: file.path,
+      patch: attributes.fetch("patch"),
+      pull_request_number: attributes.fetch("pull_request_number"),
+      violations: violations,
+    )
+  end
+end

--- a/lib/scss_lint.rb
+++ b/lib/scss_lint.rb
@@ -1,2 +1,0 @@
-module ScssLint
-end

--- a/lib/scss_lint/violation.rb
+++ b/lib/scss_lint/violation.rb
@@ -1,4 +1,4 @@
-module ScssLint
+module Scss
   class Violation
     VIOLATION_REGEX = /\A
       (?<path>.+):

--- a/spec/jobs/scss_review_job_spec.rb
+++ b/spec/jobs/scss_review_job_spec.rb
@@ -5,9 +5,9 @@ describe ScssReviewJob do
   describe ".perform" do
     it "enqueues completed file review job with violations" do
       config = ConfigOptions.new("", "scss.yml")
-      runner = ScssLint::Runner.new(config)
+      runner = Linters::ScssLint.new(config)
       allow(Resque).to receive(:enqueue)
-      allow(ScssLint::Runner).to receive(:new).and_return(runner)
+      allow(Linters::ScssLint).to receive(:new).and_return(runner)
       allow(runner).
         to receive(:execute_linter).and_return(linter_response)
 
@@ -33,9 +33,9 @@ describe ScssReviewJob do
 
     context "runner fails" do
       it "does not enqueue a completed file review job" do
-        runner = instance_double(ScssLint::Runner)
+        runner = instance_double(Linters::ScssLint)
         allow(runner).to receive(:violations_for).and_raise(RuntimeError)
-        allow(ScssLint::Runner).to receive(:new).and_return(runner)
+        allow(Linters::ScssLint).to receive(:new).and_return(runner)
         allow(Resque).to receive(:enqueue)
 
         expect do

--- a/spec/lib/haml_lint/violation_spec.rb
+++ b/spec/lib/haml_lint/violation_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 require "haml_lint/violation"
 
-describe HamlLint::Violation do
+describe Haml::Violation do
   describe ".parsable?" do
     context "given a valid violation" do
       it "should parse full violation" do
-        parsable = HamlLint::Violation.parsable?(violation_string)
+        parsable = Haml::Violation.parsable?(violation_string)
 
         expect(parsable).to eq(true)
       end
@@ -13,7 +13,7 @@ describe HamlLint::Violation do
 
     context "given a valid error" do
       it "parses the error" do
-        parsable = HamlLint::Violation.parsable?(error_message)
+        parsable = Haml::Violation.parsable?(error_message)
 
         expect(parsable).to eq(true)
       end
@@ -21,7 +21,7 @@ describe HamlLint::Violation do
 
     context "given an invalid violation" do
       it "should not be able to parse" do
-        parsable = HamlLint::Violation.parsable?("Invalid string")
+        parsable = Haml::Violation.parsable?("Invalid string")
 
         expect(parsable).to eq(false)
       end
@@ -31,7 +31,7 @@ describe HamlLint::Violation do
   describe "#line_number" do
     context "when the message is a violation" do
       it "returns line number" do
-        violation = HamlLint::Violation.new(violation_string(line_number: 1))
+        violation = Haml::Violation.new(violation_string(line_number: 1))
 
         expect(violation.line_number).to eq(1)
       end
@@ -39,7 +39,7 @@ describe HamlLint::Violation do
 
     context "when the message is an error" do
       it "returns the reported line number plus one" do
-        violation = HamlLint::Violation.new(error_message(line_number: 4))
+        violation = Haml::Violation.new(error_message(line_number: 4))
 
         expect(violation.line_number).to eq(5)
       end
@@ -47,11 +47,11 @@ describe HamlLint::Violation do
 
     context "when the message is invalid" do
       it "raises with an invalid string" do
-        violation = HamlLint::Violation.new("invalid string")
+        violation = Haml::Violation.new("invalid string")
 
         expect { violation.line_number }.
           to raise_error(
-            HamlLint::ViolationParseError,
+            Haml::ViolationParseError,
             /Violation: "invalid string"/,
           )
       end
@@ -62,7 +62,7 @@ describe HamlLint::Violation do
     context "when the message is a violation" do
       it "returns the message" do
         message = "Trailing Whitespace Violation: It should not have whitespace"
-        violation = HamlLint::Violation.new(violation_string(message: message))
+        violation = Haml::Violation.new(violation_string(message: message))
 
         expect(violation.message).to eq(message)
       end
@@ -71,7 +71,7 @@ describe HamlLint::Violation do
     context "when the message is an error" do
       it "returns the message" do
         message = "You did it wrong"
-        violation = HamlLint::Violation.new(error_message(message: message))
+        violation = Haml::Violation.new(error_message(message: message))
 
         expect(violation.message).to eq(message)
       end
@@ -79,11 +79,11 @@ describe HamlLint::Violation do
 
     context "when the message is invalid" do
       it "raises with an invalid string" do
-        violation = HamlLint::Violation.new("invalid string")
+        violation = Haml::Violation.new("invalid string")
 
         expect { violation.message }.
           to raise_error(
-            HamlLint::ViolationParseError,
+            Haml::ViolationParseError,
             /Violation: "invalid string"/,
           )
       end

--- a/spec/lib/linters/haml_lint_spec.rb
+++ b/spec/lib/linters/haml_lint_spec.rb
@@ -1,18 +1,18 @@
 require "spec_helper"
 require "config_options"
-require "haml_lint/runner"
 require "source_file"
+require "linters/haml_lint"
 
-describe HamlLint::Runner do
+describe Linters::HamlLint do
   describe "#violations_for" do
     it "executes proper command to get violations" do
       config = ConfigOptions.new("", "haml.yml")
       file = SourceFile.new("file.html.haml", "let x = 'Hello'")
       system_call = SystemCall.new
       allow(system_call).to receive(:call).and_return("")
-      runner = HamlLint::Runner.new(config, system_call: system_call)
+      linter = Linters::HamlLint.new(config, system_call: system_call)
 
-      runner.violations_for(file)
+      linter.violations_for(file)
 
       expect(system_call).to have_received(:call).with("haml-lint .")
     end
@@ -20,9 +20,9 @@ describe HamlLint::Runner do
     it "returns all violations" do
       config = ConfigOptions.new("", "haml.yml")
       file = SourceFile.new("bar.html.haml", file_content)
-      runner = HamlLint::Runner.new(config)
+      linter = Linters::HamlLint.new(config)
 
-      violations = runner.violations_for(file)
+      violations = linter.violations_for(file)
 
       expect(violations.size).to eq(2)
     end
@@ -31,9 +31,9 @@ describe HamlLint::Runner do
       it "returns no violations" do
         config = ConfigOptions.new("exclude: foo/*", "haml.yml")
         file = SourceFile.new("foo/bar.html.haml", file_content)
-        runner = HamlLint::Runner.new(config)
+        linter = Linters::HamlLint.new(config)
 
-        violations = runner.violations_for(file)
+        violations = linter.violations_for(file)
 
         expect(violations.size).to eq(0)
       end
@@ -48,9 +48,9 @@ describe HamlLint::Runner do
         HAML
         config = ConfigOptions.new("", "haml.yml")
         file = SourceFile.new("bar.html.haml", invalid_content)
-        runner = HamlLint::Runner.new(config)
+        linter = Linters::HamlLint.new(config)
 
-        violations = runner.violations_for(file)
+        violations = linter.violations_for(file)
 
         expect(violations.size).to eq(1)
         expect(violations.first[:line]).to eq 3

--- a/spec/lib/linters/scss_lint_spec.rb
+++ b/spec/lib/linters/scss_lint_spec.rb
@@ -1,18 +1,18 @@
 require "spec_helper"
 require "config_options"
-require "scss_lint/runner"
 require "source_file"
+require "linters/scss_lint"
 
-describe ScssLint::Runner do
+describe Linters::ScssLint do
   describe "#violations_for" do
     it "executes proper command to get violations" do
       config = ConfigOptions.new("", "scss.yml")
       file = SourceFile.new("file.scss", "let x = 'Hello'")
       system_call = SystemCall.new
       allow(system_call).to receive(:call).and_return("")
-      runner = ScssLint::Runner.new(config, system_call: system_call)
+      linter = Linters::ScssLint.new(config, system_call: system_call)
 
-      runner.violations_for(file)
+      linter.violations_for(file)
 
       expect(system_call).to have_received(:call).with("scss-lint")
     end
@@ -20,9 +20,9 @@ describe ScssLint::Runner do
     it "returns all violations" do
       config = ConfigOptions.new("", "scss.yml")
       file = SourceFile.new("foo/bar.scss", file_content)
-      runner = ScssLint::Runner.new(config)
+      linter = Linters::ScssLint.new(config)
 
-      violations = runner.violations_for(file)
+      violations = linter.violations_for(file)
 
       expect(violations.size).to eq(2)
     end
@@ -31,9 +31,9 @@ describe ScssLint::Runner do
       it "returns no violations" do
         config = ConfigOptions.new("exclude: foo/*", "scss.yml")
         file = SourceFile.new("foo/bar.scss", file_content)
-        runner = ScssLint::Runner.new(config)
+        linter = Linters::ScssLint.new(config)
 
-        violations = runner.violations_for(file)
+        violations = linter.violations_for(file)
 
         expect(violations.size).to eq(0)
       end
@@ -48,9 +48,9 @@ describe ScssLint::Runner do
         SCSS
         config = ConfigOptions.new("", "scss.yml")
         file = SourceFile.new("bar.scss", invalid_content)
-        runner = ScssLint::Runner.new(config)
+        linter = Linters::ScssLint.new(config)
 
-        violations = runner.violations_for(file)
+        violations = linter.violations_for(file)
 
         expect(violations.size).to eq(1)
         expect(violations.first[:line]).to eq 3

--- a/spec/lib/scss_lint/violation_spec.rb
+++ b/spec/lib/scss_lint/violation_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 require "scss_lint/violation"
 
-describe ScssLint::Violation do
+describe Scss::Violation do
   describe ".parsable?" do
     context "given a valid violation" do
       it "should parse full violation" do
-        parsable = ScssLint::Violation.parsable?(violation_string)
+        parsable = Scss::Violation.parsable?(violation_string)
 
         expect(parsable).to eq(true)
       end
@@ -13,7 +13,7 @@ describe ScssLint::Violation do
 
     context "fiven a valid error" do
       it "parses the error" do
-        parsable = ScssLint::Violation.parsable?(error_message)
+        parsable = Scss::Violation.parsable?(error_message)
 
         expect(parsable).to eq(true)
       end
@@ -21,7 +21,7 @@ describe ScssLint::Violation do
 
     context "given an invalid violation" do
       it "should not be able to parse" do
-        parsable = ScssLint::Violation.parsable?("Invalid string")
+        parsable = Scss::Violation.parsable?("Invalid string")
 
         expect(parsable).to eq(false)
       end
@@ -31,7 +31,7 @@ describe ScssLint::Violation do
   describe "#line_number" do
     context "when the message is a violation" do
       it "returns line number" do
-        violation = ScssLint::Violation.new(violation_string(line_number: 1))
+        violation = Scss::Violation.new(violation_string(line_number: 1))
 
         expect(violation.line_number).to eq(1)
       end
@@ -39,7 +39,7 @@ describe ScssLint::Violation do
 
     context "when the message is an error" do
       it "returns the reported line number" do
-        violation = ScssLint::Violation.new(error_message(line_number: 4))
+        violation = Scss::Violation.new(error_message(line_number: 4))
 
         expect(violation.line_number).to eq(4)
       end
@@ -47,11 +47,11 @@ describe ScssLint::Violation do
 
     context "when the message is invalid" do
       it "raises with an invalid string" do
-        violation = ScssLint::Violation.new("invalid string")
+        violation = Scss::Violation.new("invalid string")
 
         expect { violation.line_number }.
           to raise_error(
-            ScssLint::ViolationParseError,
+            Scss::ViolationParseError,
             /Violation: "invalid string"/,
           )
       end
@@ -62,7 +62,7 @@ describe ScssLint::Violation do
     context "when the message is a violation" do
       it "returns the message" do
         message = "Trailing Whitespace Violation: It should not have whitespace"
-        violation = ScssLint::Violation.new(violation_string(message: message))
+        violation = Scss::Violation.new(violation_string(message: message))
 
         expect(violation.message).to eq(message)
       end
@@ -71,7 +71,7 @@ describe ScssLint::Violation do
     context "when the message is an error" do
       it "returns the message" do
         message = "You did it wrong"
-        violation = ScssLint::Violation.new(error_message(message: message))
+        violation = Scss::Violation.new(error_message(message: message))
 
         expect(violation.message).to eq(message)
       end
@@ -79,11 +79,11 @@ describe ScssLint::Violation do
 
     context "when the message is invalid" do
       it "raises with an invalid string" do
-        violation = ScssLint::Violation.new("invalid string")
+        violation = Scss::Violation.new("invalid string")
 
         expect { violation.message }.
           to raise_error(
-            ScssLint::ViolationParseError,
+            Scss::ViolationParseError,
             /Violation: "invalid string"/,
           )
       end


### PR DESCRIPTION
* Extracts commonalities from `ScssReviewJob` and `HamlReviewJob` into a
  new `Runner` class
* Introduces `Linters` top level namespace
* Moves `HamlLint::Runner` to `Linters::HamlLint`
* Moves `ScssLint::Runner` to `Linters::ScssLint`
* Moves `HamlLint::Violation` to `Haml::Violation` to avoid the
  `HamlLint` namespace collision. The `Haml` namespace will be removed
  in a future commit.
* Moves `ScssLint::Violation` to `Scss::Violation` to avoid the
  `ScssLint` namespace collision. The `Scss` namespace will be removed
  in a future commit.

https://trello.com/c/tNkpUewT