### PR TITLE
Add ESLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-resque: TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=haml_review,scss_review bundle exec rake jobs:work
+resque: TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=eslint_review,haml_review,scss_review bundle exec rake jobs:work

--- a/config/eslintrc
+++ b/config/eslintrc
@@ -1,0 +1,8 @@
+{
+    "rules": {},
+    "env": {
+        "es6": true,
+        "browser": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/jobs/eslint_review_job.rb
+++ b/jobs/eslint_review_job.rb
@@ -1,0 +1,14 @@
+require "resque"
+require "linters/runner"
+require "linters/eslint/options"
+
+class EslintReviewJob
+  @queue = :eslint_review
+
+  def self.perform(attributes)
+    Linters::Runner.call(
+      linter_options: Linters::Eslint::Options.new,
+      attributes: attributes,
+    )
+  end
+end

--- a/lib/linters/eslint/options.rb
+++ b/lib/linters/eslint/options.rb
@@ -1,0 +1,24 @@
+require "linters/eslint/tokenizer"
+
+module Linters
+  module Eslint
+    class Options
+      def command
+        path = File.join(File.dirname(__FILE__), "../../..")
+        File.join(path, "/node_modules/eslint/bin/eslint.js .")
+      end
+
+      def config_filename
+        ".eslintrc"
+      end
+
+      def default_config_path
+        "config/eslintrc"
+      end
+
+      def tokenizer
+        Tokenizer.new
+      end
+    end
+  end
+end

--- a/lib/linters/eslint/tokenizer.rb
+++ b/lib/linters/eslint/tokenizer.rb
@@ -1,0 +1,30 @@
+module Linters
+  module Eslint
+    class Tokenizer
+      VIOLATION_REGEX = /\A
+        (?<line_number>.+):
+        (?<column_number>\d+)\s+
+        (?<violation_level>\w+)\s+
+        (?<message>.+)
+        \n?
+      \z/x
+
+      def parse(text)
+        text.split("\n").map { |line| tokenize(line) }.compact
+      end
+
+      private
+
+      def tokenize(line)
+        matches = VIOLATION_REGEX.match(line)
+
+        if matches
+          {
+            line: matches[:line_number].to_i,
+            message: matches[:message],
+          }
+        end
+      end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "linters",
+  "version": "1.0.0",
+  "description": "Use Node for JS based linters",
+  "dependencies": {
+    "eslint": "^2.12.0",
+    "eslint-config-airbnb": "^8.0.0",
+    "eslint-config-littlebits": "^0.5.0",
+    "eslint-config-semistandard": "^6.0.1",
+    "eslint-config-standard": "^5.2.0",
+    "eslint-plugin-import": "^1.6.0",
+    "eslint-plugin-jsx-a11y": "^1.0.3",
+    "eslint-plugin-promise": "^1.1.0",
+    "eslint-plugin-react": "^5.0.1",
+    "eslint-plugin-standard": "^1.3.1"
+  }
+}

--- a/spec/jobs/eslint_review_job_spec.rb
+++ b/spec/jobs/eslint_review_job_spec.rb
@@ -1,0 +1,32 @@
+require "jobs/eslint_review_job"
+
+RSpec.describe EslintReviewJob do
+  include LintersHelper
+
+  context "when file contains violations" do
+    it "reports violations" do
+      expect_violations_in_file(
+        content: content,
+        filename: "foo/test.js",
+        violations: [
+          {
+            line: 2,
+            message: "'hello' is defined but never used  no-unused-vars",
+          },
+          {
+            line: 3,
+            message: "Unexpected console statement       no-console",
+          },
+        ],
+      )
+    end
+  end
+
+  def content
+    <<~JS
+      'use strict';
+      function hello() { }
+      console.log('world')
+    JS
+  end
+end


### PR DESCRIPTION
This is using a ruby wrapper for ESLint.

This will not ignore files natively, since ignore file isn't sent as
part of the job payload.

Hound proper handles ignoring JS files, and does not schedule jobs if
files are ignored. So, we are okay for now.
At some point we might want to consider supporting native file ignores,
but then we'll be scheduling jobs for files that are simply ignored.