### PR TITLE
New rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.3.1
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install
+
+COPY . /usr/src/app
+
+CMD bundle exec rake jobs:work

--- a/config/scss.yml
+++ b/config/scss.yml
@@ -97,7 +97,7 @@ linters:
 
   LeadingZero:
     enabled: true
-    style: include_zero # or 'exclude_zero'
+    style: exclude_zero # or 'include_zero'
 
   MergeableSelector:
     enabled: true

--- a/config/scss.yml
+++ b/config/scss.yml
@@ -110,7 +110,7 @@ linters:
 
   NestingDepth:
     enabled: true
-    max_depth: 4
+    max_depth: 3
     ignore_parent_selectors: false
 
   PlaceholderInExtend:
@@ -127,6 +127,7 @@ linters:
 
   PropertySortOrder:
     enabled: true
+    order: smacss
     ignore_unspecified: false
     min_properties: 2
     separate_groups: false
@@ -210,7 +211,7 @@ linters:
 
   StringQuotes:
     enabled: true
-    style: double_quotes # or single_quotes
+    style: single_quotes
 
   TrailingSemicolon:
     enabled: true

--- a/config/scss.yml
+++ b/config/scss.yml
@@ -7,9 +7,6 @@ plugin_directories: ['.scss-linters']
 # installed)
 plugin_gems: []
 
-# Default severity of all linters.
-severity: warning
-
 linters:
   BangFormat:
     enabled: true
@@ -44,7 +41,7 @@ linters:
     enabled: true
 
   DisableLinterReason:
-    enabled: false
+    enabled: true
 
   DuplicateProperty:
     enabled: true
@@ -72,7 +69,7 @@ linters:
     style: short # or 'long'
 
   HexNotation:
-    enabled: true
+    enabled: false
     style: lowercase # or 'uppercase'
 
   HexValidation:
@@ -115,10 +112,6 @@ linters:
 
   PlaceholderInExtend:
     enabled: false
-
-  PrivateNamingConvention:
-    enabled: false
-    prefix: _
 
   PropertyCount:
     enabled: true
@@ -165,11 +158,11 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+    convention: hyphenated_BEM # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
+    allowed_shorthands: [1, 2]
 
   SingleLinePerProperty:
     enabled: true
@@ -188,10 +181,6 @@ linters:
 
   SpaceAfterPropertyName:
     enabled: true
-
-  SpaceAfterVariableColon:
-    enabled: false
-    style: one_space # or 'no_space', 'at_least_one_space' or 'one_space_or_newline'
 
   SpaceAfterVariableName:
     enabled: true
@@ -220,7 +209,7 @@ linters:
     enabled: true
 
   TrailingZero:
-    enabled: false
+    enabled: true
 
   TransitionAll:
     enabled: false
@@ -238,8 +227,8 @@ linters:
     enabled: true
 
   VariableForProperty:
-    enabled: false
-    properties: []
+    enabled: true
+    properties: [font]
 
   VendorPrefix:
     enabled: true


### PR DESCRIPTION
#### DisableLinterReason 
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#disablelinterreason
Nos obliga a dar una razón (en comentarios) si deshabilitamos el linter en algún archivo.

#### HexNotation
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#hexnotation
Permitir que los hex puedan estar en mayúsculas o minúsculas.

#### SelectorFormat
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#selectorformat
Usar selectores de BEM 🎉 

#### Shorthand
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#shorthand
Me pasa que los shorthands del estilo:
```
margin: 10px 5px 10px;
```
No es más claro que:
```
margin: 10px 5px 10px 5px;
```
Por eso propongo cambiar las reglas para que solo sugiera shorthands de dos valores.

#### TrailingZero
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#trailingzero
Self explanatory.

#### VariableForProperty
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#variableforproperty
Ya estamos usando variables para los colores, creo que los fonts son otro caso claro para el uso de variables.