### PR TITLE
Lint specific filename

### DIFF
--- a/lib/linters/eslint/options.rb
+++ b/lib/linters/eslint/options.rb
@@ -3,9 +3,10 @@ require "linters/eslint/tokenizer"
 module Linters
   module Eslint
     class Options
-      def command
+      def command(filename)
         path = File.join(File.dirname(__FILE__), "../../..")
-        File.join(path, "/node_modules/eslint/bin/eslint.js .")
+        cmd = "/node_modules/eslint/bin/eslint.js #{filename}"
+        File.join(path, cmd)
       end
 
       def config_filename

--- a/lib/linters/haml_lint/options.rb
+++ b/lib/linters/haml_lint/options.rb
@@ -3,8 +3,8 @@ require "linters/haml_lint/tokenizer"
 module Linters
   module HamlLint
     class Options
-      def command
-        "haml-lint ."
+      def command(filename)
+        "haml-lint #{filename}"
       end
 
       def config_filename

--- a/lib/linters/runner.rb
+++ b/lib/linters/runner.rb
@@ -24,7 +24,7 @@ module Linters
 
     def call
       output = Lint.call(
-        command: linter_options.command,
+        command: linter_options.command(filename),
         config_file: config_file,
         source_file: source_file,
       )

--- a/lib/linters/scss_lint/options.rb
+++ b/lib/linters/scss_lint/options.rb
@@ -3,8 +3,8 @@ require "linters/scss_lint/tokenizer"
 module Linters
   module ScssLint
     class Options
-      def command
-        "scss-lint"
+      def command(filename)
+        "scss-lint #{filename}"
       end
 
       def config_filename

--- a/spec/jobs/eslint_review_job_spec.rb
+++ b/spec/jobs/eslint_review_job_spec.rb
@@ -3,7 +3,7 @@ require "jobs/eslint_review_job"
 RSpec.describe EslintReviewJob do
   include LintersHelper
 
-  context "when file contains violations" do
+  context "when file with .js extention contains violations" do
     it "reports violations" do
       expect_violations_in_file(
         content: content,
@@ -16,6 +16,21 @@ RSpec.describe EslintReviewJob do
           {
             line: 3,
             message: "Unexpected console statement       no-console",
+          },
+        ],
+      )
+    end
+  end
+
+  context "when file with .jsx extention contains violations" do
+    it "reports violations" do
+      expect_violations_in_file(
+        content: "import React from 'react';",
+        filename: "foo/test.jsx",
+        violations: [
+          {
+            line: 1,
+            message: "Parsing error: 'import' and 'export' may appear only with 'sourceType: module'",
           },
         ],
       )


### PR DESCRIPTION
ESLint by default lints only .js extensions.
Let's ensure the linter lints the file + filename in the review process.