### PR TITLE
Extract common output parsing logic into a class

### DIFF
--- a/lib/linters/eslint/tokenizer.rb
+++ b/lib/linters/eslint/tokenizer.rb
@@ -10,20 +10,7 @@ module Linters
       \z/x
 
       def parse(text)
-        text.split("\n").map { |line| tokenize(line) }.compact
-      end
-
-      private
-
-      def tokenize(line)
-        matches = VIOLATION_REGEX.match(line)
-
-        if matches
-          {
-            line: matches[:line_number].to_i,
-            message: matches[:message],
-          }
-        end
+        Linters::Tokenizer.new(text, VIOLATION_REGEX).parse
       end
     end
   end

--- a/lib/linters/jshint/tokenizer.rb
+++ b/lib/linters/jshint/tokenizer.rb
@@ -10,20 +10,7 @@ module Linters
       \z/x
 
       def parse(text)
-        text.split("\n").map { |line| tokenize(line) }.compact
-      end
-
-      private
-
-      def tokenize(line)
-        matches = VIOLATION_REGEX.match(line)
-
-        if matches
-          {
-            line: matches[:line_number].to_i,
-            message: matches[:message],
-          }
-        end
+        Linters::Tokenizer.new(text, VIOLATION_REGEX).parse
       end
     end
   end

--- a/lib/linters/runner.rb
+++ b/lib/linters/runner.rb
@@ -1,6 +1,7 @@
 require "linters/config"
 require "linters/source_file"
 require "linters/lint"
+require "linters/tokenizer"
 require "jobs/completed_file_review_job"
 
 module Linters

--- a/lib/linters/scss_lint/tokenizer.rb
+++ b/lib/linters/scss_lint/tokenizer.rb
@@ -11,20 +11,7 @@ module Linters
       \z/x
 
       def parse(text)
-        text.split("\n").map { |line| tokenize(line) }.compact
-      end
-
-      private
-
-      def tokenize(line)
-        matches = VIOLATION_REGEX.match(line)
-
-        if matches
-          {
-            line: matches[:line_number].to_i,
-            message: matches[:message],
-          }
-        end
+        Linters::Tokenizer.new(text, VIOLATION_REGEX).parse
       end
     end
   end

--- a/lib/linters/tokenizer.rb
+++ b/lib/linters/tokenizer.rb
@@ -1,0 +1,27 @@
+module Linters
+  class Tokenizer
+    def initialize(text, regex)
+      @text = text
+      @regex = regex
+    end
+
+    def parse
+      text.split("\n").map { |line| tokenize(line, regex) }.compact
+    end
+
+    private
+
+    attr_reader :text, :regex
+
+    def tokenize(line, regex)
+      matches = regex.match(line)
+
+      if matches
+        {
+          line: matches[:line_number].to_i,
+          message: matches[:message],
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was quite a bit of duplication for parsing violation output in
most tokenizers. I extracted this into a higher-level `Tokenizer` class.