### PR TITLE
Set default Ruby version for RuboCop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,1 +1,2 @@
---- {}
+AllCops:
+  TargetRubyVersion: 2.3

--- a/spec/jobs/rubocop_review_job_spec.rb
+++ b/spec/jobs/rubocop_review_job_spec.rb
@@ -5,13 +5,20 @@ RSpec.describe RubocopReviewJob do
 
   context "when file contains violations" do
     it "reports violations" do
+      content = <<~EOS
+        # frozen_string_literal: true
+        def foo(bar:, baz:)
+          bar
+        end
+      EOS
+
       expect_violations_in_file(
-        content: "def yo; 42 end\n",
+        content: content,
         filename: "foo/test.rb",
         violations: [
           {
-            line: 1,
-            message: "Avoid single-line method definitions.",
+            line: 2,
+            message: "Unused method argument - baz.",
           },
         ],
       )

--- a/spec/support/helpers/linters_helper.rb
+++ b/spec/support/helpers/linters_helper.rb
@@ -1,5 +1,5 @@
 module LintersHelper
-  def expect_violations_in_file(content:, filename:, config: "", violations:)
+  def expect_violations_in_file(content:, filename:, config: "{}", violations:)
     attributes = {
       "config" => config,
       "content" => content,


### PR DESCRIPTION
Otherwise, RuboCop will assume an oldest supported Ruby version if it's
not specified by the user. From their docs:
```
What MRI version of the Ruby interpreter is the inspected code intended
to run on? (If there is more than one, set this to the lowest version.)
If a value is specified for TargetRubyVersion then it is used.
Else if .ruby-version exists and it contains an MRI version it is used.
Otherwise we fallback to the oldest officially supported Ruby version
(2.0).
```

Thus, we should either default it to `2.3`, or tell users that get
strange "token" (code parse) errors to specify `TargetRubyVersion` in
their custom config.