### PR TITLE
Deep merge configs

### DIFF
--- a/lib/linters/config.rb
+++ b/lib/linters/config.rb
@@ -8,19 +8,27 @@ module Linters
     end
 
     def to_yaml
-      to_hash.to_yaml
+      merge.to_yaml
     end
 
     def to_json
-      to_hash.to_json
+      merge.to_json
     end
 
     private
 
     attr_reader :custom_config, :default_config_path
 
-    def to_hash
-      default_config.merge(custom_config)
+    def merge
+      deep_merger = ->(_key, hash1, hash2) do
+        if Hash === hash1 && Hash === hash2
+          hash1.merge(hash2, &deep_merger)
+        else
+          hash2
+        end
+      end
+
+      default_config.merge(custom_config, &deep_merger)
     end
 
     def default_config

--- a/spec/lib/linters/config_spec.rb
+++ b/spec/lib/linters/config_spec.rb
@@ -2,7 +2,7 @@ require "linters/config"
 
 describe Linters::Config do
   describe "#to_yaml" do
-    it "returns a merged config" do
+    it "returns a deeply merged config" do
       content = <<~EOL
         linters:
           AltText:
@@ -15,7 +15,14 @@ describe Linters::Config do
 
       result = config.to_yaml
 
-      expect(result).to include(content)
+      expect(result).to include <<-EOS
+  AltText:
+    enabled: true
+      EOS
+      expect(result).to include <<-EOS
+  ColorVariable:
+    enabled: true
+      EOS
     end
   end
 end


### PR DESCRIPTION
In RuboCop's case, we'll lose the default `TargetRubyVersion` config
if custom config file contains `AllCops` key.

For example, a custom config like:
```yaml
AllCops:
  Exclude:
    - 'specs/helpers/**/*'
```
Will revert to using the lowest supported `TargetRubyVersion` because
our current merge strategy only merges top-level keys, thus causing the
final config to be `{"AllCops"=>{"Exclude"=>["specs/helpers/**/*"]}}`.