### PR TITLE
Upgrade to ESLint version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "1.0.0",
   "description": "Use Node for JS based linters",
   "dependencies": {
-    "eslint": "^2.12.0",
-    "eslint-config-airbnb": "^8.0.0",
+    "eslint": "^3.4.0",
+    "eslint-config-airbnb": "^10.0.1",
     "eslint-config-littlebits": "^0.5.0",
     "eslint-config-semistandard": "^6.0.1",
     "eslint-config-standard": "^5.2.0",
     "eslint-plugin-import": "^1.6.0",
-    "eslint-plugin-jsx-a11y": "^1.0.3",
+    "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-react": "^5.0.1",
+    "eslint-plugin-react": "^6.2.0",
     "eslint-plugin-standard": "^1.3.1",
     "jshint": "^2.9.2"
   }

--- a/spec/jobs/eslint_review_job_spec.rb
+++ b/spec/jobs/eslint_review_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EslintReviewJob do
         violations: [
           {
             line: 2,
-            message: "'hello' is defined but never used  no-unused-vars",
+            message: "Unexpected console statement  no-console",
           },
         ],
       )
@@ -23,7 +23,7 @@ RSpec.describe EslintReviewJob do
       config = <<~JSON
         {
           "rules": {
-            "no-unused-vars": "off"
+            "no-console": "off"
           }
         }
       JSON
@@ -45,7 +45,7 @@ RSpec.describe EslintReviewJob do
         violations: [
           {
             line: 2,
-            message: "'hello' is defined but never used  no-unused-vars",
+            message: "Unexpected console statement  no-console",
           },
         ],
       )
@@ -55,7 +55,7 @@ RSpec.describe EslintReviewJob do
   def content
     <<~JS
       'use strict';
-      function hello() { }
+      console.log('hello');
     JS
   end
 end


### PR DESCRIPTION
ESLint 3 is being encouraged by most modern JS projects, and includes a
whole bunch of new stuff but [without breaking anything from ESLint
2.x](http://eslint.org/docs/user-guide/migrating-to-3.0.0).

It's blocking us using certain newer features of ESLint from within
Hound (a .js config file, for example), so this PR upgrades ESLint to
3.4.0, and updates its peers where necessary.