### PR TITLE
Support ERB in CoffeeScript

### DIFF
--- a/lib/linters/coffeelint/options.rb
+++ b/lib/linters/coffeelint/options.rb
@@ -4,9 +4,7 @@ module Linters
   module Coffeelint
     class Options
       def command(filename)
-        path = File.join(File.dirname(__FILE__), "../../..")
-        cmd = "/node_modules/coffeelint/bin/coffeelint #{filename}"
-        File.join(path, cmd)
+        "#{replace_erb_tags(filename)} && #{coffeelint(filename)}"
       end
 
       def config_filename
@@ -28,6 +26,16 @@ module Linters
           content: content,
           default_config_path: "config/coffeelint.json",
         )
+      end
+
+      def replace_erb_tags(filename)
+        "sed -i.bak 's/<%.*%>/123/g' #{filename}"
+      end
+
+      def coffeelint(filename)
+        path = File.join(File.dirname(__FILE__), "../../..")
+        cmd = "/node_modules/coffeelint/bin/coffeelint #{filename}"
+        File.join(path, cmd)
       end
     end
   end

--- a/spec/jobs/coffeelint_review_job_spec.rb
+++ b/spec/jobs/coffeelint_review_job_spec.rb
@@ -46,6 +46,31 @@ RSpec.describe CoffeelintReviewJob do
     end
   end
 
+  context "when file contains erb" do
+    it "lints it as coffeescript" do
+      content = <<~EOS
+        class myObj
+          foo = () ->
+            <%= @my_variable %>
+      EOS
+
+      expect_violations_in_file(
+        content: content,
+        filename: "foo/test.coffee",
+        violations: [
+          {
+            line: 1,
+            message: "Class name should be UpperCamelCased. class name: myObj.",
+          },
+          {
+            line: 2,
+            message: "Empty parameter list is forbidden.",
+          },
+        ],
+      )
+    end
+  end
+
   def content
     <<~EOS
       class myObj


### PR DESCRIPTION
Updates `Coffeelint::Options` to replace ERB tags in the file with the
value `123`. This is to keep feature parity with the previous linter,
removed in https://github.com/houndci/hound/pull/1206

https://trello.com/c/pj5BdqFU