### PR TITLE
Escape hashtag character in CoffeeLint regex

### DIFF
--- a/lib/linters/coffeelint/tokenizer.rb
+++ b/lib/linters/coffeelint/tokenizer.rb
@@ -2,8 +2,10 @@ module Linters
   module Coffeelint
     class Tokenizer
       VIOLATION_REGEX = /\A
-        .*#
-        (?<line_number>\d+):\s
+        .*\#
+        (?<line_number>\d+):
+        (?<parse_error_details>.+:\d+:)?
+        \s
         (?<message>.+)
         \n?
       \z/x

--- a/spec/jobs/coffeelint_review_job_spec.rb
+++ b/spec/jobs/coffeelint_review_job_spec.rb
@@ -46,6 +46,35 @@ RSpec.describe CoffeelintReviewJob do
     end
   end
 
+  context "when file content is long" do
+    it "finds violation on the correct line" do
+      content = <<~EOS
+        class MyClass
+          construtor: ->
+            foo1()
+            foo2()
+            foo3()
+            foo4()
+            foo5()
+            foo6()
+            foo7()
+            foo8()
+              foo9()
+      EOS
+
+      expect_violations_in_file(
+        content: content,
+        filename: "foo/test.js",
+        violations: [
+          {
+            line: 11,
+            message: "error: unexpected indentation",
+          },
+        ],
+      )
+    end
+  end
+
   context "when file contains erb" do
     it "lints it as coffeescript" do
       content = <<~EOS


### PR DESCRIPTION
The `#` character beings a comment line in Ruby regex, when
in `x` (whitespace ignore) mode.
Thus, it needs be escaped to be considered part of the regex.

Also, optionally ignore code syntax errors, that show up in the form of:
```
✗ #11: [stdin]:11:1: error: unexpected indentation
```