### PR TITLE
Update eslint to v3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "coffeelint": "^1.15.7",
-    "eslint": "^3.5.0",
+    "eslint": "^3.7.1",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-config-littlebits": "^0.5.1",
     "eslint-config-semistandard": "^7.0.0",


### PR DESCRIPTION
Updated ESLint version to [v3.7.1](http://eslint.org/blog/2016/10/eslint-v3.7.1-released).
Particularly, [v3.6.0](http://eslint.org/blog/2016/09/eslint-v3.6.0-released) is an important change because it includes partial support for ES2017, which introduces some new syntax (e.g. `async` `await`).

Anyway, thank you for the great software! I love Hound ❤️ 