### PR TITLE
Fix Credo line number parsing

### DIFF
--- a/lib/linters/credo/tokenizer.rb
+++ b/lib/linters/credo/tokenizer.rb
@@ -2,8 +2,9 @@ module Linters
   module Credo
     class Tokenizer
       VIOLATION_REGEX = /\A
-        (?<file_name>.+):
-        (?<line_number>\d+):\s+
+        (?<file_name>[^:]+):
+        (?<line_number>\d+):
+        ((?<column_number>\d+):)?\s+
         (?<violation_level>\w+):\s+
         (?<message>.+)
         \n?

--- a/spec/lib/linters/credo/tokenizer_spec.rb
+++ b/spec/lib/linters/credo/tokenizer_spec.rb
@@ -1,0 +1,30 @@
+require "linters/tokenizer"
+require "linters/credo/tokenizer"
+
+describe Linters::Credo::Tokenizer do
+  describe "#parse" do
+    it "parses line numbers when columns provided" do
+      tokenizer = Linters::Credo::Tokenizer.new
+
+      parsed = tokenizer.parse <<~OUTPUT
+        test_elixir.ex:5:11: R: Modules should have a @moduledoc tag.
+      OUTPUT
+
+      expect(parsed).to eq(
+        [{ line: 5, message: "Modules should have a @moduledoc tag." }],
+      )
+    end
+
+    it "parses line numbers when columns not provided" do
+      tokenizer = Linters::Credo::Tokenizer.new
+
+      parsed = tokenizer.parse <<~OUTPUT
+        test_elixir.ex:5: R: Modules should have a @moduledoc tag.
+      OUTPUT
+
+      expect(parsed).to eq(
+        [{ line: 5, message: "Modules should have a @moduledoc tag." }],
+      )
+    end
+  end
+end


### PR DESCRIPTION
The regex was incorrectly parsing the column number instead of the line number.
This updates the regex and adds a test from a real world example to protect this
from coming up again in the future.