### PR TITLE
Add reek code smell tool as a "linter"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.3.1"
 
 gem "haml_lint"
 gem "rake"
+gem "reek"
 gem "resque"
 gem "resque-sentry"
 gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,20 @@ GEM
   specs:
     ast (2.3.0)
     awesome_print (1.7.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     byebug (9.0.5)
+    codeclimate-engine-rb (0.4.0)
+      virtus (~> 1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     dotenv (2.1.1)
+    equalizer (0.0.10)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     haml (4.0.7)
@@ -15,6 +26,7 @@ GEM
       rake (>= 10, < 13)
       rubocop (>= 0.36.0)
       sysexits (~> 1.1)
+    ice_nine (0.11.2)
     mono_logger (1.1.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -29,6 +41,10 @@ GEM
     redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    reek (4.5.4)
+      codeclimate-engine-rb (~> 0.4.0)
+      parser (~> 2.3.1, >= 2.3.1.2)
+      rainbow (~> 2.0)
     resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
@@ -69,10 +85,16 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     sysexits (1.2.0)
+    thread_safe (0.3.5)
     tilt (2.0.5)
     unicode-display_width (1.1.2)
     vegas (0.1.11)
       rack (>= 1.0.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
 
 PLATFORMS
   ruby
@@ -83,6 +105,7 @@ DEPENDENCIES
   dotenv
   haml_lint
   rake
+  reek
   resque
   resque-sentry
   rspec

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This service uses the following linters:
   * [rubocop](https://github.com/bbatsov/rubocop) for Ruby
   * [scss-lint](https://github.com/brigade/scss-lint) for SCSS
   * [credo](https://github.com/rrrene/credo) for Elixir
+  * [reek](https://github.com/troessner/reek) for Ruby code smells
 
 ## Getting Started
 

--- a/bin/resque
+++ b/bin/resque
@@ -2,6 +2,6 @@
 
 export TERM_CHILD=1
 export RESQUE_TERM_TIMEOUT=7
-export QUEUES=eslint_review,haml_review,jshint_review,rubocop_review,scss_review,coffeelint_review,tslint_review,credo_review
+export QUEUES=eslint_review,haml_review,jshint_review,rubocop_review,scss_review,coffeelint_review,tslint_review,credo_review,reek_review
 
 bundle exec rake jobs:work

--- a/jobs/reek_review_job.rb
+++ b/jobs/reek_review_job.rb
@@ -1,0 +1,14 @@
+require "resque"
+require "linters/runner"
+require "linters/reek/options"
+
+class ReekReviewJob
+  @queue = :reek_review
+
+  def self.perform(attributes)
+    Linters::Runner.call(
+      linter_options: Linters::Reek::Options.new,
+      attributes: attributes,
+    )
+  end
+end

--- a/lib/linters/reek/options.rb
+++ b/lib/linters/reek/options.rb
@@ -1,0 +1,24 @@
+require "linters/base/options"
+require "linters/reek/tokenizer"
+
+module Linters
+  module Reek
+    class Options < Linters::Base::Options
+      def command(filename)
+        "reek --no-wiki-links --single-line --no-progress #{filename}"
+      end
+
+      def config_filename
+        ".reek"
+      end
+
+      def tokenizer
+        Tokenizer.new
+      end
+
+      def config_content(content)
+        content
+      end
+    end
+  end
+end

--- a/lib/linters/reek/tokenizer.rb
+++ b/lib/linters/reek/tokenizer.rb
@@ -1,0 +1,16 @@
+module Linters
+  module Reek
+    class Tokenizer
+      VIOLATION_REGEX = /\A
+        (?<path>.+):
+        (?<line_number>\d+):\s
+        (?<message>.+: .+)
+        \n?
+      \z/x
+
+      def parse(text)
+        Linters::Tokenizer.new(text, VIOLATION_REGEX).parse
+      end
+    end
+  end
+end

--- a/spec/jobs/reek_review_job_spec.rb
+++ b/spec/jobs/reek_review_job_spec.rb
@@ -1,0 +1,32 @@
+require "jobs/reek_review_job"
+
+RSpec.describe ReekReviewJob do
+  include LintersHelper
+
+  context "when file contains a smell" do
+    it "reports the violation" do
+      content = <<~EOS
+        class Smelly # IrresponsibleModule: Smelly has no descriptive comment
+          def x      # UncommunicativeMethodName: Smelly#x has the name 'x'
+            puts 'stinky'
+          end
+        end
+      EOS
+
+      expect_violations_in_file(
+        content: content,
+        filename: "foo/test.rb",
+        violations: [
+          {
+            line: 1,
+            message: "IrresponsibleModule: Smelly has no descriptive comment",
+          },
+          {
+            line: 2,
+            message: "UncommunicativeMethodName: Smelly#x has the name 'x'",
+          },
+        ]
+      )
+    end
+  end
+end

--- a/spec/lib/linters/reek/tokenizer_spec.rb
+++ b/spec/lib/linters/reek/tokenizer_spec.rb
@@ -1,0 +1,16 @@
+require "linters/tokenizer"
+require "linters/reek/tokenizer"
+
+describe Linters::Reek::Tokenizer do
+  describe "#parse" do
+    it "parses line numbers when columns provided" do
+      input = "test.rb:9: ModuleName: LintersHelper has no descriptive comment"
+      expected_message = "ModuleName: LintersHelper has no descriptive comment"
+      tokenizer = Linters::Reek::Tokenizer.new
+
+      parsed = tokenizer.parse(input)
+
+      expect(parsed).to eq([{ line: 9, message: expected_message }])
+    end
+  end
+end


### PR DESCRIPTION
"Linter" in quotes as it is a code **_quality_** tool, not style adherence per se.

Reek will tell you where in your project you have potential code smells. The code smell detection it provides is listen on their project page: https://github.com/troessner/reek/blob/master/docs/Code-Smells.md

This pull request is an initial attempt at getting Reek into Hound. Comments and questions forthcoming in the commits' code.