### PR TITLE
Create abstract base options class w/annotations

### DIFF
--- a/lib/linters/base/options.rb
+++ b/lib/linters/base/options.rb
@@ -1,0 +1,42 @@
+module Linters
+  module Base
+    # Base Options class for all linters
+    # @abstract
+    class Options
+      # Linter command that will run against a file
+      # @param _filename [String] relative path to the file being checked
+      # @return [String] cli command to run
+      def command(_filename)
+        not_implemented!(__method__)
+      end
+
+      # Filename for configuration file which linter expects by default.
+      # @return [String] path and filename of the config file the linter wants
+      def config_filename
+        not_implemented!(__method__)
+      end
+
+      # Object to parse linter output, returning hash with line numbers and
+      # messages of the issues
+      # @return [#parse] a Tokenizer object implementing `#parse`
+      def tokenizer
+        not_implemented!(__method__)
+      end
+
+      # Returns content of linter's configuration file.  If the configuration
+      # needs merging -- the default config needs to be combined with repo's
+      # config -- then that work should happen here.
+      # @param _content [String] contents of a config file
+      # @return [Sring, nil] the contents of the config file or nil
+      def config_content(_content)
+        not_implemented!(__method__)
+      end
+
+      private
+
+      def not_implemented!(method)
+        raise NotImplementedError, "implement ##{method} in your Options class"
+      end
+    end
+  end
+end

--- a/lib/linters/coffeelint/options.rb
+++ b/lib/linters/coffeelint/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/coffeelint/tokenizer"
 
 module Linters
   module Coffeelint
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         "#{replace_erb_tags(filename)} && #{coffeelint(filename)}"
       end

--- a/lib/linters/credo/options.rb
+++ b/lib/linters/credo/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/credo/tokenizer"
 
 module Linters
   module Credo
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         mix("credo #{filename} --strict --all --format=flycheck")
       end

--- a/lib/linters/eslint/options.rb
+++ b/lib/linters/eslint/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/eslint/tokenizer"
 
 module Linters
   module Eslint
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         path = File.join(File.dirname(__FILE__), "../../..")
         cmd = "/node_modules/eslint/bin/eslint.js #{filename}"

--- a/lib/linters/haml_lint/options.rb
+++ b/lib/linters/haml_lint/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/haml_lint/tokenizer"
 
 module Linters
   module HamlLint
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         "haml-lint #{filename}"
       end

--- a/lib/linters/jshint/options.rb
+++ b/lib/linters/jshint/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/jshint/tokenizer"
 
 module Linters
   module Jshint
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         path = File.join(File.dirname(__FILE__), "../../..")
         cmd = "/node_modules/jshint/bin/jshint #{filename}"

--- a/lib/linters/rubocop/options.rb
+++ b/lib/linters/rubocop/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/rubocop/tokenizer"
 
 module Linters
   module Rubocop
-    class Options
+    class Options < Linters::Base::Options
       def command(_filename)
         "rubocop"
       end

--- a/lib/linters/scss_lint/options.rb
+++ b/lib/linters/scss_lint/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/scss_lint/tokenizer"
 
 module Linters
   module ScssLint
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         "scss-lint #{filename}"
       end

--- a/lib/linters/tslint/options.rb
+++ b/lib/linters/tslint/options.rb
@@ -1,8 +1,9 @@
+require "linters/base/options"
 require "linters/tslint/tokenizer"
 
 module Linters
   module Tslint
-    class Options
+    class Options < Linters::Base::Options
       def command(filename)
         path = File.join(File.dirname(__FILE__), "../../..")
         cmd = "/node_modules/tslint/bin/tslint #{filename}"

--- a/spec/lib/linters/base/options_spec.rb
+++ b/spec/lib/linters/base/options_spec.rb
@@ -1,0 +1,13 @@
+require "linters/base/options"
+
+RSpec.describe Linters::Base::Options do
+  describe "#command" do
+    it "raises a NotImplementedError" do
+      options = Class.new(Linters::Base::Options).new
+      exception = NotImplementedError
+      message = 'implement #command in your Options class'
+
+      expect { options.command("a.rb") }.to raise_exception(exception, message)
+    end
+  end
+end


### PR DESCRIPTION
The options classes across all linters behave similarly, but can vary
here and there. Because there is no real comprehensive documentation of
these objects -- what they do, what they accept, what they return --
there is some friction when attempting to create a new linter and the
associated objects.

This commit holds a base abstract Options class that acts as a contract
for the `Options` classes that need implementing. Raising
NotImplementedError clearly dictates what methods are needed. The Yarddoc
style method annotations communicate what it is that they should do.