### PR TITLE
Set Hound up to Flog Ruby changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby "2.3.1"
 
+gem "flog"
 gem "haml_lint"
 gem "rake"
 gem "reek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,10 @@ GEM
     equalizer (0.0.10)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    flog (4.5.0)
+      path_expander (~> 1.0)
+      ruby_parser (~> 3.1, > 3.1.0)
+      sexp_processor (~> 4.4)
     haml (4.0.7)
       tilt
     haml_lint (0.19.0)
@@ -32,6 +36,7 @@ GEM
     multipart-post (2.0.0)
     parser (2.3.3.1)
       ast (~> 2.2)
+    path_expander (1.0.1)
     powerpack (0.1.1)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -74,12 +79,15 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    ruby_parser (3.8.4)
+      sexp_processor (~> 4.1)
     sass (3.4.22)
     scss_lint (0.50.2)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
     sentry-raven (1.2.3)
       faraday (>= 0.7.6, < 0.10.x)
+    sexp_processor (4.7.0)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -103,6 +111,7 @@ DEPENDENCIES
   awesome_print
   byebug
   dotenv
+  flog
   haml_lint
   rake
   reek
@@ -117,4 +126,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/bin/resque
+++ b/bin/resque
@@ -2,6 +2,6 @@
 
 export TERM_CHILD=1
 export RESQUE_TERM_TIMEOUT=7
-export QUEUES=eslint_review,haml_review,jshint_review,rubocop_review,scss_review,coffeelint_review,tslint_review,credo_review,reek_review
+export QUEUES=eslint_review,haml_review,jshint_review,rubocop_review,scss_review,coffeelint_review,tslint_review,credo_review,reek_review,flog_review
 
 bundle exec rake jobs:work

--- a/lib/jobs/flog_review_job.rb
+++ b/lib/jobs/flog_review_job.rb
@@ -1,0 +1,14 @@
+require "resque"
+require "linters/runner"
+require "linters/flog/options"
+
+class FlogReviewJob
+  @queue = :flog_review
+
+  def self.perform(attributes)
+    Linters::Runner.call(
+      attributes: attributes,
+      linter_options: Linters::Flog::Options.new,
+    )
+  end
+end

--- a/lib/linters/flog/options.rb
+++ b/lib/linters/flog/options.rb
@@ -1,0 +1,23 @@
+require "linters/flog/tokenizer"
+
+module Linters
+  module Flog
+    class Options
+      def command(filename)
+        "flog --all --continue --quiet #{filename}"
+      end
+
+      def config_content(config)
+        config
+      end
+
+      def config_filename
+        ".flog"
+      end
+
+      def tokenizer
+        Tokenizer.new
+      end
+    end
+  end
+end

--- a/lib/linters/flog/tokenizer.rb
+++ b/lib/linters/flog/tokenizer.rb
@@ -1,0 +1,32 @@
+module Linters
+  module Flog
+    class Tokenizer
+      MIN_COMPLEXITY_THRESHOLD = 25
+      VIOLATION_REGEX = /\A
+        \s*
+        (?<score>\d+.\d+):\s
+        (?<method>.+\#\w+)
+        (?<file>.+):
+        (?<line_number>\d+)
+        \n?
+      \z/x
+
+      def parse(text)
+        text.split("\n").map { |line| tokenize(line) }.compact
+      end
+
+      private
+
+      def tokenize(line)
+        matches = VIOLATION_REGEX.match(line)
+
+        if matches && (matches[:score] || 0).to_i >= MIN_COMPLEXITY_THRESHOLD
+          {
+            line: matches[:line_number].to_i,
+            message: "#{matches[:method]} is a complex method",
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/flog_review_job_spec.rb
+++ b/spec/jobs/flog_review_job_spec.rb
@@ -1,0 +1,32 @@
+require "jobs/flog_review_job"
+
+RSpec.describe FlogReviewJob do
+  include LintersHelper
+
+  context "when method in file has a high flog score" do
+    it "reports the violation" do
+      content = <<~EOS
+        class BadFlog
+          def some_method
+            super
+          rescue StandardError => error
+            if this(&wat=foo) == true
+              that = "something"
+            end
+          end
+        end
+      EOS
+
+      expect_violations_in_file(
+        content: content,
+        filename: "foo/test.rb",
+        violations: [
+          {
+            line: 2,
+            message: "BadFlog#some_method is a complex method",
+          },
+        ],
+      )
+    end
+  end
+end

--- a/spec/lib/linters/flog/tokenizer_spec.rb
+++ b/spec/lib/linters/flog/tokenizer_spec.rb
@@ -1,0 +1,19 @@
+require "linters/flog/tokenizer"
+
+module Linters
+  module Flog
+    RSpec.describe Tokenizer do
+      describe "#parse" do
+        it "parses line numbers when score is high enough" do
+          input = "  28.2: BadFlog#some_method              lib/bad_flog.rb:2\n"
+          expected_message = "BadFlog#some_method is a complex method"
+          tokenizer = Tokenizer.new
+
+          parsed = tokenizer.parse(input)
+
+          expect(parsed).to eq([{ line: 2, message: expected_message }])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before, we only checked Ruby files using Rubocop. This only allowed us to comment on the style of the files. Added a Flog integration which will comment on Ruby methods that are too complex.

![](http://i.giphy.com/12HBh5vQa1j2Gk.gif)