### PR TITLE
Add babel-eslint and esprima modules so eslint can select either as parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "6.6.0"
   },
   "dependencies": {
+    "babel-eslint": "^7.1.1",
     "coffeelint": "^1.15.7",
     "eslint": "^3.7.1",
     "eslint-config-airbnb": "^11.1.0",
@@ -16,6 +17,7 @@
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-react": "^6.2.2",
     "eslint-plugin-standard": "^2.0.0",
+    "esprima": "^3.1.3",
     "jshint": "^2.9.2",
     "tslint": "^3.15.1",
     "typescript": "^2.0.0"


### PR DESCRIPTION
Addresses: https://github.com/houndci/hound/issues/1309

This PR allows your `.eslintrc` to select `babel-eslint` or `esprima` as alternative eslint parsers to `espree`.

I'm not certain that `babel` isn't also required because it's not listed as a dependency in babel-eslint, but I left it out.