### PR TITLE
Add link to code smell explanation

### DIFF
--- a/lib/linters/reek/options.rb
+++ b/lib/linters/reek/options.rb
@@ -5,7 +5,7 @@ module Linters
   module Reek
     class Options < Linters::Base::Options
       def command(filename)
-        "reek --no-wiki-links --single-line --no-progress #{filename}"
+        "reek --single-line --no-progress #{filename}"
       end
 
       def config_filename

--- a/lib/linters/reek/tokenizer.rb
+++ b/lib/linters/reek/tokenizer.rb
@@ -1,15 +1,25 @@
 module Linters
   module Reek
+    # Reek Tokenizer class will parse and return a hash containing the line of
+    # the infraction, and a message with a link to see further information
     class Tokenizer
       VIOLATION_REGEX = /\A
         (?<path>.+):
         (?<line_number>\d+):\s
-        (?<message>.+: .+)
+        (?<message>.*)
         \n?
       \z/x
 
       def parse(text)
-        Linters::Tokenizer.new(text, VIOLATION_REGEX).parse
+        parser_results = Linters::Tokenizer.new(text, VIOLATION_REGEX).parse
+
+        parser_results.map do |result|
+          result[:message].
+            gsub!("]", ").").
+            gsub!(" [", ". [More info](")
+
+          result
+        end
       end
     end
   end

--- a/spec/jobs/reek_review_job_spec.rb
+++ b/spec/jobs/reek_review_job_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe ReekReviewJob do
         violations: [
           {
             line: 1,
-            message: "IrresponsibleModule: Smelly has no descriptive comment",
+            message: "IrresponsibleModule: Smelly has no descriptive comment. [More info](https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md).",
           },
           {
             line: 2,
-            message: "UncommunicativeMethodName: Smelly#x has the name 'x'",
+            message: "UncommunicativeMethodName: Smelly#x has the name 'x'. [More info](https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md).",
           },
         ]
       )

--- a/spec/lib/linters/reek/tokenizer_spec.rb
+++ b/spec/lib/linters/reek/tokenizer_spec.rb
@@ -4,11 +4,21 @@ require "linters/reek/tokenizer"
 describe Linters::Reek::Tokenizer do
   describe "#parse" do
     it "parses line numbers when columns provided" do
-      input = "test.rb:9: ModuleName: LintersHelper has no descriptive comment"
-      expected_message = "ModuleName: LintersHelper has no descriptive comment"
-      tokenizer = Linters::Reek::Tokenizer.new
+      explanation_link = "https://github.com/troessner/reek/wiki.md"
 
-      parsed = tokenizer.parse(input)
+      original_input = [
+        "text.rb:9:",                  # file and line number
+        "FakeReekModule:",             # Reek module which found infraction
+        "Error [#{explanation_link}]", # link to wiki explaining infraction
+      ].join(" ")
+
+      expected_message = [
+        "FakeReekModule:",                          # Reek module
+        "Error. [More info](#{explanation_link}).", # link converted to markdown
+      ].join(" ")
+
+      tokenizer = Linters::Reek::Tokenizer.new
+      parsed = tokenizer.parse(original_input)
 
       expect(parsed).to eq([{ line: 9, message: expected_message }])
     end


### PR DESCRIPTION
When reek finds a code smell it will provide a link to the project's
wiki where an explanation for that code smell is. There is further
information about what it's "smelling", how it may be configured (on or
off) and what it's checking for.

This commit/PR provides that link, but formatted with markdown in order to
reduce noise in the comment.