### PR TITLE
Use one job queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules/
+node_modules/
 _build
 deps
 yarn-debug.log*

--- a/bin/resque
+++ b/bin/resque
@@ -2,6 +2,6 @@
 
 export TERM_CHILD=1
 export RESQUE_TERM_TIMEOUT=7
-export QUEUES=eslint_review,haml_review,jshint_review,rubocop_review,scss_review,coffeelint_review,tslint_review,credo_review,reek_review,flog_review
+export QUEUES=linters,eslint_review,haml_review,jshint_review,rubocop_review,scss_review,coffeelint_review,tslint_review,credo_review,reek_review,flog_review
 
 bundle exec rake jobs:work

--- a/jobs/linters_job.rb
+++ b/jobs/linters_job.rb
@@ -1,0 +1,31 @@
+require "resque"
+require "linters/runner"
+
+require "linters/coffeelint/options"
+require "linters/credo/options"
+require "linters/eslint/options"
+require "linters/flake8/options"
+require "linters/flog/options"
+require "linters/haml_lint/options"
+require "linters/jshint/options"
+require "linters/reek/options"
+require "linters/rubocop/options"
+require "linters/scss_lint/options"
+require "linters/tslint/options"
+
+class LintersJob
+  @queue = :linters
+
+  def self.perform(attributes)
+    Linters::Runner.call(
+      linter_options: linter_options(attributes["linter_name"]),
+      attributes: attributes,
+    )
+  end
+
+  def self.linter_options(linter_name)
+    linter = linter_name.split("_").map(&:capitalize).join
+    const_get("Linters::#{linter}::Options").new
+  end
+  private_class_method :linter_options
+end

--- a/spec/jobs/linters_job_spec.rb
+++ b/spec/jobs/linters_job_spec.rb
@@ -1,0 +1,39 @@
+require "jobs/linters_job"
+
+RSpec.describe LintersJob do
+  include LintersHelper
+
+  context "when linter name is a single word" do
+    it "reports violations" do
+      expect_violations_in_file(
+        config: "",
+        content: "puts 'hello world'\n",
+        filename: "foo/bar.rb",
+        linter_name: "rubocop",
+        violations: [
+          {
+            line: 1,
+            message: "Missing frozen string literal comment.",
+          },
+        ],
+      )
+    end
+  end
+
+  context "when linter name is multiple words" do
+    it "reports violations" do
+      expect_violations_in_file(
+        config: "",
+        content: "%div\n  #main",
+        filename: "foo/bar.html.haml",
+        linter_name: "haml_lint",
+        violations: [
+          {
+            line: 2,
+            message: "Files should end with a trailing newline",
+          },
+        ],
+      )
+    end
+  end
+end

--- a/spec/support/helpers/linters_helper.rb
+++ b/spec/support/helpers/linters_helper.rb
@@ -1,12 +1,18 @@
 module LintersHelper
-  def expect_violations_in_file(content:, filename:, config: "{}", violations:)
+  def expect_violations_in_file(
+    config: "{}",
+    content:,
+    filename:,
+    linter_name: "foo",
+    violations:
+  )
     attributes = {
       "config" => config,
       "content" => content,
       "commit_sha" => "anything",
       "filename" => filename,
       "patch" => "",
-      "linter_name" => "foo",
+      "linter_name" => linter_name,
       "pull_request_number" => "1",
     }
     allow(Resque).to receive(:enqueue)


### PR DESCRIPTION
Our `QUEUE` situation is getting a bit large.

We only need one queue, since we pass the `linter_name` in the payload.

The idea is to slowly move Hound main app, to use this queue -- maybe
start with new linters first.