### PR TITLE
Add stylelint-scss plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "eslint-config-airbnb": "^11.1.0",
     "eslint-config-littlebits": "^0.5.1",
     "eslint-config-semistandard": "^7.0.0",
-    "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-import-resolver-meteor": "^0.3.4",
+    "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-meteor": "^4.0.1",
@@ -25,6 +25,7 @@
     "stylelint": "^7.9.0",
     "stylelint-config-standard": "^16.0.0",
     "stylelint-order": "^0.4.1",
+    "stylelint-scss": "^1.4.4",
     "stylelint-selector-bem-pattern": "^1.0.0",
     "tslint": "^4.4.2",
     "typescript": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,7 +1914,7 @@ lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
-lodash@>=3.10.0, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@>=3.10.0, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2328,7 +2328,7 @@ postcss-less@^0.14.0:
   dependencies:
     postcss "^5.0.21"
 
-postcss-media-query-parser@^0.2.0:
+postcss-media-query-parser@^0.2.0, postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
 
@@ -2368,7 +2368,7 @@ postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.1.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-value-parser@^3.1.1, postcss-value-parser@^3.2.3:
+postcss-value-parser@^3.1.1, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
@@ -2829,6 +2829,17 @@ stylelint-order@^0.4.1:
     postcss "^5.2.16"
     stylelint "^7.9.0"
 
+stylelint-scss@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-1.4.4.tgz#091fcbd8b648c78ec3899853e54b975e0256cd4a"
+  dependencies:
+    lodash "^4.11.1"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^2.0.0"
+    postcss-value-parser "^3.3.0"
+    stylelint "^7.0.3"
+
 stylelint-selector-bem-pattern@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-selector-bem-pattern/-/stylelint-selector-bem-pattern-1.0.0.tgz#9420e1bb8fe5e014547f91aedb635ab5df86b070"
@@ -2838,7 +2849,7 @@ stylelint-selector-bem-pattern@^1.0.0:
     postcss-bem-linter "^2.1.0"
     stylelint ">=3.0.2"
 
-stylelint@>=3.0.2, stylelint@^7.9.0:
+stylelint@>=3.0.2, stylelint@^7.0.3, stylelint@^7.9.0:
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.9.0.tgz#b8d9ea20f887ab351075c6aded9528de24509327"
   dependencies:


### PR DESCRIPTION
[stylelint-scss](https://github.com/kristerkari/stylelint-scss) is a
commonly used plugin for stylelint and we should provide support for it.

To enable it users can specify the following in their stylelint config:
```json
{
  "plugins": [
    "stylelint-scss"
  ]
}
```