### PR TITLE
Report shelled out command errors

### DIFF
--- a/lib/linters/command_result.rb
+++ b/lib/linters/command_result.rb
@@ -1,0 +1,22 @@
+module Linters
+  class CommandResult
+    attr_reader :output
+
+    def initialize(output:, status:)
+      @output = output
+      @status = status
+    end
+
+    def error?
+      !status.success? && output_present?
+    end
+
+    private
+
+    attr_reader :status
+
+    def output_present?
+      !output.nil? && !output.empty?
+    end
+  end
+end

--- a/lib/linters/lint.rb
+++ b/lib/linters/lint.rb
@@ -26,8 +26,6 @@ module Linters
 
     def run_linter_on_system(directory)
       system_call(directory).execute
-    rescue SystemCall::NonZeroExitStatusError => e
-      e.output
     end
 
     def system_call(directory)

--- a/lib/linters/system_call.rb
+++ b/lib/linters/system_call.rb
@@ -1,4 +1,5 @@
 require "open3"
+require "linters/command_result"
 
 module Linters
   class SystemCall
@@ -9,25 +10,11 @@ module Linters
 
     def execute
       output, status = Open3.capture2e(command, chdir: directory)
-
-      if status.success?
-        output
-      else
-        raise NonZeroExitStatusError.new("Command: '#{command}'", output)
-      end
+      CommandResult.new(output: output, status: status)
     end
 
     private
 
     attr_reader :command, :directory
-
-    class NonZeroExitStatusError < StandardError
-      attr_reader :output
-
-      def initialize(message, output)
-        super(message)
-        @output = output
-      end
-    end
   end
 end

--- a/spec/lib/linters/command_result_spec.rb
+++ b/spec/lib/linters/command_result_spec.rb
@@ -1,0 +1,45 @@
+require "linters/command_result"
+
+describe Linters::CommandResult do
+  describe "#error?" do
+    context "when there is some output" do
+      context "when return code is success" do
+        it "returns false" do
+          status = instance_double("Process::Status", success?: true)
+          comand_result = described_class.new(output: "foo", status: status)
+
+          expect(comand_result).not_to be_error
+        end
+      end
+
+      context "when return code is not success" do
+        it "returns true" do
+          status = instance_double("Process::Status", success?: false)
+          comand_result = described_class.new(output: "foo", status: status)
+
+          expect(comand_result).to be_error
+        end
+      end
+    end
+
+    context "when output is blank" do
+      context "when return code is success" do
+        it "returns false" do
+          status = instance_double("Process::Status", success?: true)
+          comand_result = described_class.new(output: "", status: status)
+
+          expect(comand_result).not_to be_error
+        end
+      end
+
+      context "when return code is not success" do
+        it "returns false" do
+          status = instance_double("Process::Status", success?: false)
+          comand_result = described_class.new(output: "", status: status)
+
+          expect(comand_result).not_to be_error
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/linters/runner_spec.rb
+++ b/spec/lib/linters/runner_spec.rb
@@ -1,0 +1,42 @@
+require "resque"
+require "linters/runner"
+require "linters/rubocop/options"
+
+describe Linters::Runner do
+  describe "#call" do
+    context "when linter encounters an error" do
+      it "enqueues a job with an error" do
+        config = <<~EOS
+          Style/StringLiterals:
+          Enabled: true
+        EOS
+        attributes = {
+          "commit_sha" => "foobar",
+          "config" => config,
+          "content" => "puts 'hello world'",
+          "filename" => "foo.rb",
+          "linter_name" => "rubocop",
+          "patch" => "",
+          "pull_request_number" => "123",
+        }
+        allow(Resque).to receive(:enqueue)
+
+        described_class.call(
+          linter_options: Linters::Rubocop::Options.new,
+          attributes: attributes,
+        )
+
+        expect(Resque).to have_received(:enqueue).with(
+          CompletedFileReviewJob,
+          commit_sha: attributes["commit_sha"],
+          filename: attributes["filename"],
+          linter_name: attributes["linter_name"],
+          patch: attributes["patch"],
+          pull_request_number: attributes["pull_request_number"],
+          violations: [],
+          error: a_string_including("Warning: unrecognized cop Enabled found"),
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/linters/system_call_spec.rb
+++ b/spec/lib/linters/system_call_spec.rb
@@ -9,9 +9,12 @@ describe Linters::SystemCall do
         directory: ".",
       )
 
-      output = system.execute
+      result = system.execute
 
-      expect(output).to eq("Hello World!")
+      expect(result).to have_attributes(
+        output: "Hello World!",
+        error?: false,
+      )
     end
 
     it "captures stderr" do
@@ -20,9 +23,12 @@ describe Linters::SystemCall do
         directory: ".",
       )
 
-      output = system.execute
+      result = system.execute
 
-      expect(output).to eq("Hello World!")
+      expect(result).to have_attributes(
+        output: "Hello World!",
+        error?: false,
+      )
     end
 
     it "captures and concats stdout and stderr" do
@@ -31,36 +37,28 @@ describe Linters::SystemCall do
         directory: ".",
       )
 
-      output = system.execute
+      result = system.execute
 
-      expect(output).to eq("Hello Stdout!Hello Stderr!")
+      expect(result).to have_attributes(
+        output: "Hello Stdout!Hello Stderr!",
+        error?: false,
+      )
     end
   end
 
-  context "running an invalid command" do
-    it "raises an error" do
+  context "when running an invalid command" do
+    it "returns an result with the error output" do
       system = Linters::SystemCall.new(
-        command: "printf",
+        command: "ruby invalid",
         directory: ".",
       )
 
-      expect { system.execute }.
-        to raise_error(
-          Linters::SystemCall::NonZeroExitStatusError,
-          "Command: 'printf'",
-        )
-    end
+      result = system.execute
 
-    it "stores the command's output on the error" do
-      system = Linters::SystemCall.new(
-        command: "printf",
-        directory: ".",
+      expect(result).to have_attributes(
+        output: "ruby: No such file or directory -- invalid (LoadError)\n",
+        error?: true,
       )
-
-      expect { system.execute }.to raise_error do |error|
-        expect(error.output).
-          to match(/(usage: printf format)|(printf: missing operand)/)
-      end
     end
   end
 end

--- a/spec/support/helpers/linters_helper.rb
+++ b/spec/support/helpers/linters_helper.rb
@@ -27,6 +27,7 @@ module LintersHelper
       patch: attributes["patch"],
       pull_request_number: attributes["pull_request_number"],
       violations: violations,
+      error: nil,
     )
   end
 end


### PR DESCRIPTION
Various linters don't adhere to one strict methodology on when to return
`0` or `1` or `2` as exit codes.
For example, RuboCop returns `1` when there are violations and `2` when
any other problem is encountered. However, JSHint uses `2` when
violations are found/reported.

So, instead if there is output, but no violations could be parsed, we
can assume that something else went wrong and thus report that output as
an error.