### PR TITLE
Report only unique error output lines

### DIFF
--- a/lib/linters/runner.rb
+++ b/lib/linters/runner.rb
@@ -33,7 +33,7 @@ module Linters
       violations = linter_options.tokenizer.parse(result.output)
 
       if violations.empty? && result.error?
-        complete_file_review([], error: result.output)
+        complete_file_review([], error: result.output.lines.uniq.join)
       else
         complete_file_review(violations)
       end

--- a/spec/lib/linters/runner_spec.rb
+++ b/spec/lib/linters/runner_spec.rb
@@ -37,6 +37,55 @@ describe Linters::Runner do
           error: a_string_including("Warning: unrecognized cop Enabled found"),
         )
       end
+
+      context "when error output is a recursive stack-trace" do
+        it "reports error using its unique lines" do
+          attributes = {
+            "commit_sha" => "foobar",
+            "config" => "",
+            "content" => "puts 'hello world'",
+            "filename" => "foo.rb",
+            "linter_name" => "rubocop",
+            "patch" => "",
+            "pull_request_number" => "123",
+          }
+          output = <<~EOS
+            something went wrong:
+              foo.rb
+              foo.rb
+              foo.rb
+              Stack buffer overflow
+          EOS
+          command_result = instance_double(
+            "CommandResult",
+            output: output,
+            error?: true,
+          )
+          allow(Resque).to receive(:enqueue)
+          allow(Linters::CommandResult).to receive(:new).
+            and_return(command_result)
+
+          described_class.call(
+            linter_options: Linters::Rubocop::Options.new,
+            attributes: attributes,
+          )
+
+          expect(Resque).to have_received(:enqueue).with(
+            CompletedFileReviewJob,
+            commit_sha: attributes["commit_sha"],
+            filename: attributes["filename"],
+            linter_name: attributes["linter_name"],
+            patch: attributes["patch"],
+            pull_request_number: attributes["pull_request_number"],
+            violations: [],
+            error: <<~EOS
+              something went wrong:
+                foo.rb
+                Stack buffer overflow
+            EOS
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In the case of ESLint, we are seeing a recursive stack-trace error for a
certain situation. This makes the error output very long and causes us
to send this back and store it on Hound's end. In turn, GitHub limits
the review body comment to 64KB which this error output can go over.