### PR TITLE
Strip out temp path from error outputs

### DIFF
--- a/lib/linters/runner.rb
+++ b/lib/linters/runner.rb
@@ -33,7 +33,7 @@ module Linters
       violations = linter_options.tokenizer.parse(result.output)
 
       if violations.empty? && result.error?
-        complete_file_review([], error: result.output.lines.uniq.join)
+        complete_file_review([], error: sanitize_error_output(result.output))
       else
         complete_file_review(violations)
       end
@@ -42,6 +42,11 @@ module Linters
     private
 
     attr_reader :attributes, :linter_options
+
+    def sanitize_error_output(output)
+      temp_path_pattern = %r{/tmp/.+?/|/private/var/folders/.+/.+/T/.+?/}
+      output.lines.uniq.join.gsub(temp_path_pattern, "")
+    end
 
     def source_file
       SourceFile.new(filename, attributes.fetch("content"))

--- a/spec/lib/linters/runner_spec.rb
+++ b/spec/lib/linters/runner_spec.rb
@@ -7,7 +7,7 @@ describe Linters::Runner do
     context "when linter encounters an error" do
       it "enqueues a job with an error" do
         config = <<~EOS
-          Style/StringLiterals:
+          Style/AlignHash:
           Enabled: true
         EOS
         attributes = {
@@ -34,7 +34,8 @@ describe Linters::Runner do
           patch: attributes["patch"],
           pull_request_number: attributes["pull_request_number"],
           violations: [],
-          error: a_string_including("Warning: unrecognized cop Enabled found"),
+          error:
+            start_with(".rubocop.yml: Style/AlignHash has the wrong namespace"),
         )
       end
 


### PR DESCRIPTION
Some linters will print out the filename of the config file when they
encounter an error with its contents. Since we write the config file
(and run the linters) from a temp path, the output can be sometimes
confusing. Let's strip out the temp path and just report the filename.

The test handles both unix (Heroku) and OSX temp paths.