### PR TITLE
Strip config_import lines for Credo/Elixir

### DIFF
--- a/lib/linters/credo/options.rb
+++ b/lib/linters/credo/options.rb
@@ -5,7 +5,8 @@ module Linters
   module Credo
     class Options < Linters::Base::Options
       def command(filename)
-        mix("credo #{filename} --strict --all --format=flycheck")
+        "#{strip_import_config(filename)} && " \
+          "#{mix("credo #{filename} --strict --all --format=flycheck")}"
       end
 
       def config_filename
@@ -21,6 +22,10 @@ module Linters
       end
 
       private
+
+      def strip_import_config(filename)
+        "sed -i.bak '/import_config/d' #{filename}"
+      end
 
       def mix(command)
         "MIX_EXS=#{mix_exs_path} mix #{command}"

--- a/spec/jobs/credo_review_job_spec.rb
+++ b/spec/jobs/credo_review_job_spec.rb
@@ -52,6 +52,27 @@ RSpec.describe CredoReviewJob do
     end
   end
 
+  context "when another file is imported" do
+    it "does not error" do
+      content = <<~EOS
+        # TODO: Fix
+        import_config "config/missing.exs"
+      EOS
+
+      expect_violations_in_file(
+        config: "",
+        content: content,
+        filename: "config/foo.exs",
+        violations: [
+          {
+            line: 1,
+            message: "Found a TODO tag in a comment: # TODO: Fix",
+          },
+        ],
+      )
+    end
+  end
+
   def content
     <<~EOS
       if !true do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,6 +1213,16 @@ eslint-config-semistandard@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-11.0.0.tgz#44eef7cfdfd47219e3a7b81b91b540e880bb2615"
 
+eslint-config-standard-jsx@^4.0.0, eslint-config-standard-jsx@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz#009e53c4ddb1e9ee70b4650ffe63a7f39f8836e1"
+
+eslint-config-standard-react@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-react/-/eslint-config-standard-react-5.0.0.tgz#64c7b8140172852be810a53d48ee87649ff178e3"
+  dependencies:
+    eslint-config-standard-jsx "^4.0.0"
+
 eslint-config-standard@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz#c061e4d066f379dc17cd562c64e819b4dd454591"


### PR DESCRIPTION
Credo will try to evaluate `config_import` line and look for the file
that is being imported (e.g. `config/prod.exs`). Since Hound lints one
file at a time, that file to-be-imported will not befound and cause
Credo to error, like:

```
** (Mix.Config.LoadError) could not load config config/prod.exs
    ** (File.Error) could not read file "config/prod.exs": no such file or directory
    (elixir) lib/file.ex:244: File.read!/1
    (mix) lib/mix/config.ex:180: Mix.Config.read!/2
    (mix) lib/mix/config.ex:217: anonymous fn/3 in Mix.Config.read_wildcard!/2
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:878: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:404: :erl_eval.expr/5
```

Stripping those lines from the file before linting it, solves this
issue.